### PR TITLE
Assign employees to a single division

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -363,7 +363,7 @@ export default function Home() {
           <GridView
             schedule={activeSchedule}
             employees={employees.filter(emp =>
-              (!emp.branchCode || emp.branchCode === branchCode) && (!emp.division || emp.division === division)
+              emp.branchCode === branchCode && emp.division === division
             )}
             onUpdate={handleScheduleUpdate}
             branchCode={branchCode}

--- a/components/EmployeeManager.tsx
+++ b/components/EmployeeManager.tsx
@@ -117,7 +117,9 @@ export default function EmployeeManager({ onUpdate, branchCode, division }: Empl
           id: generateId(),
           name: typeof name === 'string' ? name : String(name),
           availableDays: [...defaultDays],
-          assignedShift: getRandomShift()
+          assignedShift: getRandomShift(),
+          branchCode: branchCode || '001',
+          division: division || 'super'
         }))
 
         // Add all new employees
@@ -311,10 +313,10 @@ export default function EmployeeManager({ onUpdate, branchCode, division }: Empl
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {employees
           .filter(emp => {
-            // If context is provided, filter by it. If not, show all
-            if (branchCode && emp.branchCode && emp.branchCode !== branchCode) return false
-            if (division && emp.division && emp.division !== division) return false
-            // When employees are not tagged yet, include them
+            // Enforce strict filtering when context is provided
+            if (branchCode && division) {
+              return emp.branchCode === branchCode && emp.division === division
+            }
             return true
           })
           .map((employee) => (


### PR DESCRIPTION
Enforce strict employee scoping by division and branch to prevent cross-division assignments.

The user explicitly requested that employees should only belong to one division and branch, preventing them from being assigned or visible in other contexts. This PR ensures that employees are strictly filtered and tagged according to the selected `branchCode` and `division`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c50f7db9-b64f-49a8-bc86-279bdf173cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c50f7db9-b64f-49a8-bc86-279bdf173cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

