### PR TITLE
Fix typescript type error in build

### DIFF
--- a/lib/exportUtils.ts
+++ b/lib/exportUtils.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Schedule, Employee, Shift } from '@/types'
+import type { ParsedCSVData } from '@/lib/csvParser'
 
 export async function exportToPDF(
   element: HTMLElement,
@@ -184,7 +185,7 @@ export function importFromCSV(
         }
 
         // Parse CSV content
-        const parsedData = parser.parseCSVContent(content)
+        const parsedData = parser.parseCSVContent(content) as ParsedCSVData
         console.log('[importFromCSV] 📊 Parsed data:', {
           rows: parsedData.rows.length,
           dates: parsedData.dates.length,
@@ -237,7 +238,7 @@ export function importFromCSV(
           console.log('[importFromCSV] ✓ Schedule created:', updatedSchedule.name)
 
           // Create days for each unique date in CSV
-          parsedData.dates.forEach(date => {
+          parsedData.dates.forEach((date: string) => {
             const dateObj = new Date(date + 'T00:00:00')
             const dayName = dateObj.toLocaleDateString('es-ES', { weekday: 'long' })
 


### PR DESCRIPTION
Add explicit type annotations to resolve an 'implicit any' TypeScript error during Vercel deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-4dc47400-c2c7-41c4-aff6-ec668c6adf15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4dc47400-c2c7-41c4-aff6-ec668c6adf15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

